### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prettier"
   ],
   "main": "index.js",
-  "repository": "git@github.com:FreshEggUK/eslint-config-freshegg.git",
+  "repository": "git+https://github.com/FreshEggUK/eslint-config-freshegg.git",
   "author": "Fresh Egg <development@freshegg.com >",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
## Summary

- update the package repository metadata from an SSH GitHub URL to a public HTTPS Git URL
- make the npm package metadata easier for package registries and tooling to consume without GitHub SSH access

## Validation

- `node -e` metadata assertion
- `git diff --check`
- `pnpm --package=npm@11.13.0 dlx npm ci --ignore-scripts`
- `pnpm --package=npm@11.13.0 dlx npm run lint`
- `pnpm --package=npm@11.13.0 dlx npm pack --dry-run`

Notes:

- `npm ci --ignore-scripts` reports existing dependency audit findings; this PR does not change dependencies or lockfiles.
- `npm run lint` reports the existing React version auto-detect warning because `react` is not installed locally, then exits successfully.
- `npm pack --dry-run` reports the existing gitignore fallback warning because the repo has no `.npmignore`, then exits successfully.